### PR TITLE
Remove unused import of to_int

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LocalFilters"
 uuid = "085fde7c-5f94-55e4-8448-8bbb5db6dde9"
 authors = ["Éric Thiébaut <https://github.com/emmt>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 EasyRanges = "bd0ea217-0861-4661-bed1-3e8ea598dd25"

--- a/src/LocalFilters.jl
+++ b/src/LocalFilters.jl
@@ -44,7 +44,7 @@ export
     strel
 
 using OffsetArrays, StructuredArrays, EasyRanges, TypeUtils
-using EasyRanges: ranges, to_int
+using EasyRanges: ranges
 using Base: @propagate_inbounds, tail, OneTo
 
 function bilateralfilter end


### PR DESCRIPTION
This PR removes an unused import `EasyRanges.to_int` which has just been removed in EasyRanges v0.1.3 (which breaks this package).
